### PR TITLE
Add Azure GPT-5 decision agent and integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ for LLM-powered research agents.
   - **NewsSentimentAgent** – aggregates qualitative information and summarises it
     via an LLM.
   - **ForecastAgent** – consumes Qlib datasets and produces alpha signals.
+  - **DecisionAgent** – queries Azure OpenAI (configured for future GPT-5
+    deployments) to synthesise alpha, price action, and news into a final
+    portfolio instruction.
   - **PortfolioAgent** – converts alpha signals into target allocations with
     simple risk constraints.
   - **ExecutionAgent** – bridges to brokers via [PyTrader](https://github.com/MetaQuotes/MetaTrader5-API).
@@ -58,6 +61,28 @@ for LLM-powered research agents.
        "provider": "openai",
        "model": "gpt-4o-mini",
        "api_key": "sk-..."
+     }
+   }
+   ```
+
+   The value supplied in `model` should match the Azure deployment name configured
+   for your GPT-5-capable endpoint.
+
+   To enable Azure OpenAI deployments (e.g. a future GPT-5 capable endpoint) the
+   configuration can be extended with the deployment details:
+
+   ```json
+   {
+     "llm_research": {
+       "provider": "azure",
+       "model": "gpt-5",
+       "api_key": "<azure-openai-key>",
+       "extra": {
+         "azure_endpoint": "https://your-resource.openai.azure.com/",
+         "azure_api_version": "2024-02-15-preview",
+         "azure_deployment": "gpt5-trading",
+         "system_message": "You are GPT-5, an elite trading strategist."
+       }
      }
    }
    ```

--- a/ov_trader/agents/base.py
+++ b/ov_trader/agents/base.py
@@ -3,10 +3,21 @@
 from __future__ import annotations
 
 import abc
+import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
+try:  # pragma: no cover - optional dependency during tests
+    from openai import AzureOpenAI, OpenAI  # type: ignore
+except Exception:  # pragma: no cover
+    AzureOpenAI = None  # type: ignore
+    OpenAI = None  # type: ignore
+
 from ..config import LLMConfig
+from ..utils.logging import configure_logging
+
+
+logger = configure_logging()
 
 
 @dataclass
@@ -50,16 +61,81 @@ class LLMEnabledAgent(BaseAgent):
         )
 
     def call_model(self, prompt: str) -> str:
-        """Call the configured model.
+        """Call the configured model using the provided :class:`LLMConfig`."""
 
-        This function intentionally avoids direct API calls because credentials are
-        environment-specific.  Integrators can supply a concrete implementation via
-        dependency injection.
-        """
+        provider = (self.llm_config.provider or "").lower()
+        system_message = self.llm_config.extra.get(
+            "system_message",
+            "You are a highly capable financial analysis assistant.",
+        )
+
+        if provider in {"azure", "azure_openai"}:
+            if AzureOpenAI is None:  # pragma: no cover - import guard for environments
+                raise RuntimeError(
+                    "The openai package with Azure OpenAI support is required to use "
+                    "Azure-based models."
+                )
+
+            endpoint = self.llm_config.extra.get("azure_endpoint") or os.getenv(
+                "AZURE_OPENAI_ENDPOINT"
+            )
+            api_key = self.llm_config.api_key or os.getenv("AZURE_OPENAI_API_KEY")
+            api_version = self.llm_config.extra.get("azure_api_version") or os.getenv(
+                "AZURE_OPENAI_API_VERSION",
+            ) or "2024-02-15-preview"
+            deployment = self.llm_config.extra.get("azure_deployment") or self.llm_config.model
+
+            if not endpoint or not api_key or not deployment:
+                raise RuntimeError(
+                    "Azure OpenAI configuration incomplete. Ensure endpoint, API key, "
+                    "and deployment/model names are provided."
+                )
+
+            client = AzureOpenAI(  # type: ignore[call-arg]
+                azure_endpoint=endpoint,
+                api_key=api_key,
+                api_version=api_version,
+            )
+
+            response = client.chat.completions.create(  # type: ignore[attr-defined]
+                model=deployment,
+                temperature=self.llm_config.temperature,
+                max_tokens=self.llm_config.max_tokens,
+                messages=[
+                    {"role": "system", "content": system_message},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+
+            if not response.choices:
+                return ""
+            return response.choices[0].message.content or ""
+
+        if provider == "openai":
+            if OpenAI is None:  # pragma: no cover
+                raise RuntimeError("The openai package is required to call OpenAI models.")
+
+            api_key = self.llm_config.api_key or os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                raise RuntimeError("OpenAI API key missing. Set OPENAI_API_KEY or config.api_key")
+
+            client = OpenAI(api_key=api_key)  # type: ignore[call-arg]
+            response = client.chat.completions.create(  # type: ignore[attr-defined]
+                model=self.llm_config.model,
+                temperature=self.llm_config.temperature,
+                max_tokens=self.llm_config.max_tokens,
+                messages=[
+                    {"role": "system", "content": system_message},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+
+            if not response.choices:
+                return ""
+            return response.choices[0].message.content or ""
 
         raise NotImplementedError(
-            "No LLM integration configured. Provide an implementation that calls the "
-            "desired provider (e.g. OpenAI GPT-4, future GPT-5, TimeGen1)."
+            f"LLM provider '{self.llm_config.provider}' not supported."
         )
 
     def run(self, context: AgentContext) -> AgentContext:
@@ -68,5 +144,8 @@ class LLMEnabledAgent(BaseAgent):
             response = self.call_model(prompt)
         except NotImplementedError:
             response = "LLM integration not configured."
+        except Exception as exc:  # pragma: no cover - network/runtime failures
+            logger.exception("LLM call failed for agent %s: %s", self.name, exc)
+            response = f"LLM call failed: {exc}"
         context.shared_memory[self.name] = response
         return context

--- a/ov_trader/agents/decision_agent.py
+++ b/ov_trader/agents/decision_agent.py
@@ -1,0 +1,216 @@
+"""LLM-based decision agent that synthesises quantitative and qualitative data."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Dict, Iterable, Optional
+
+from .base import AgentContext, LLMEnabledAgent
+from ..config import LLMConfig
+from ..utils.logging import configure_logging
+
+
+logger = configure_logging()
+
+
+class DecisionAgent(LLMEnabledAgent):
+    """Use an Azure OpenAI (GPT-5) style model to issue trading actions."""
+
+    def __init__(self, llm_config: LLMConfig, top_n: int = 5) -> None:
+        super().__init__("llm_decision", llm_config)
+        self.top_n = top_n
+
+    def build_prompt(self, context: AgentContext) -> str:  # type: ignore[override]
+        alpha_scores: Dict[str, float] = context.market_state.get("alpha", {}) or {}
+        market_data: Dict[str, Dict[str, float]] = context.market_state.get("market_data", {}) or {}
+        news_summary = context.shared_memory.get("news_sentiment")
+
+        focus_symbol = self._select_focus_symbol(alpha_scores, market_data)
+        alpha_section = self._format_alpha_section(alpha_scores)
+        market_section = self._format_market_section(focus_symbol, market_data)
+        news_section = news_summary if news_summary else "No news sentiment summary available."
+
+        instructions = (
+            "Follow this deliberate decision process:\n"
+            "1. Quantitative review: interpret the Qlib alpha signals, highlighting magnitude and sign.\n"
+            "2. Market structure: analyse the recent price and technical snapshot to infer trend, momentum, and volatility.\n"
+            "3. News context: examine the qualitative summary for catalysts and risks.\n"
+            "4. Synthesis: integrate the evidence to choose a single action (buy, sell, hold) with a recommended position size."
+        )
+
+        return (
+            "You are GPT-5, an advanced trading strategist embedded in a portfolio research simulator. "
+            "Use the provided market intelligence to recommend an action that aims to beat the broad market in simulation.\n"
+            f"Timestamp: {context.timestamp or 'unknown'}\n"
+            f"Focus symbol: {focus_symbol or 'not enough data'}\n\n"
+            f"### Qlib alpha signals (top {self.top_n})\n{alpha_section or 'No alpha data available.'}\n\n"
+            f"### Market feature snapshot for {focus_symbol or 'N/A'}\n{market_section}\n\n"
+            f"### News and sentiment overview\n{news_section}\n\n"
+            f"{instructions}\n\n"
+            "When reasoning, explicitly reference numbers from the datasets above. "
+            "Respond with a JSON object containing the following keys:\n"
+            "- \"symbol\": ticker analysed.\n"
+            "- \"action\": one of \"buy\", \"sell\", or \"hold\".\n"
+            "- \"confidence\": integer between 0 and 100.\n"
+            "- \"target_weight\": recommended portfolio weight between -1.0 and 1.0.\n"
+            "- \"thesis\": concise synthesis (~3 sentences) combining alpha, market data, and news.\n"
+            "- \"risk_notes\": explicit downside risks or invalidation points.\n"
+            "- \"analysis\": bullet-style breakdown of how each data source influenced the decision.\n"
+            "Return *only* the JSON object with no additional commentary."
+        )
+
+    def run(self, context: AgentContext) -> AgentContext:  # type: ignore[override]
+        prompt = self.build_prompt(context)
+        try:
+            raw_response = self.call_model(prompt)
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.exception("Decision agent failed to query LLM: %s", exc)
+            fallback = self._fallback_decision(context)
+            context.shared_memory[self.name] = {
+                "prompt": prompt,
+                "error": str(exc),
+                "fallback": fallback,
+            }
+            if fallback:
+                context.market_state["llm_decision"] = fallback
+            return context
+
+        parsed = self._parse_response(raw_response)
+        payload = {
+            "prompt": prompt,
+            "response": raw_response,
+            "parsed": parsed,
+        }
+
+        if parsed:
+            context.market_state["llm_decision"] = parsed
+        else:
+            fallback = self._fallback_decision(context)
+            if fallback:
+                payload["fallback"] = fallback
+                context.market_state["llm_decision"] = fallback
+
+        context.shared_memory[self.name] = payload
+        return context
+
+    def _select_focus_symbol(
+        self,
+        scores: Dict[str, float],
+        market_data: Dict[str, Dict[str, float]],
+    ) -> Optional[str]:
+        if not scores:
+            return None
+
+        available = [symbol for symbol in scores if symbol in market_data]
+        if available:
+            return max(available, key=lambda symbol: abs(scores[symbol]))
+
+        return max(scores.items(), key=lambda item: abs(item[1]))[0]
+
+    def _format_alpha_section(self, scores: Dict[str, float]) -> str:
+        if not scores:
+            return ""
+
+        ordered = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+        top = ordered[: self.top_n]
+        bottom: Iterable[tuple[str, float]] = []
+        if len(ordered) > self.top_n:
+            bottom = ordered[-self.top_n :]
+
+        lines = ["Top ranked signals:"]
+        for symbol, score in top:
+            lines.append(f"- {symbol}: {score:+.4f}")
+
+        bottom = list(bottom)
+        if bottom:
+            lines.append("Lowest ranked signals:")
+            for symbol, score in bottom:
+                lines.append(f"- {symbol}: {score:+.4f}")
+
+        return "\n".join(lines)
+
+    def _format_market_section(
+        self,
+        symbol: Optional[str],
+        market_data: Dict[str, Dict[str, float]],
+    ) -> str:
+        if not symbol or symbol not in market_data:
+            return "No detailed market snapshot available."
+
+        snapshot = market_data[symbol]
+        lines = []
+        as_of = snapshot.get("as_of")
+        if as_of:
+            lines.append(f"As of: {as_of}")
+
+        for key, value in snapshot.items():
+            if key == "as_of":
+                continue
+            lines.append(f"{key}: {value:.4f}")
+
+        return "\n".join(lines) if lines else "No detailed market snapshot available."
+
+    def _parse_response(self, response: str) -> Optional[Dict[str, object]]:
+        if not response:
+            return None
+
+        candidate = self._extract_json_block(response)
+        if candidate is None:
+            return None
+
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            return None
+
+        if isinstance(parsed, dict):
+            return parsed
+        return None
+
+    def _extract_json_block(self, text: str) -> Optional[str]:
+        cleaned = text.strip()
+        if not cleaned:
+            return None
+
+        if cleaned.startswith("```"):
+            cleaned = re.sub(r"^```[a-zA-Z0-9]*\n", "", cleaned)
+            if cleaned.endswith("```"):
+                cleaned = cleaned[:-3]
+
+        match = re.search(r"\{.*\}", cleaned, re.DOTALL)
+        if match:
+            return match.group(0)
+
+        if cleaned.startswith("{") and cleaned.endswith("}"):
+            return cleaned
+        return None
+
+    def _fallback_decision(self, context: AgentContext) -> Optional[Dict[str, object]]:
+        scores: Dict[str, float] = context.market_state.get("alpha", {}) or {}
+        if not scores:
+            return None
+
+        symbol, score = max(scores.items(), key=lambda item: abs(item[1]))
+        if score > 0:
+            action = "buy"
+        elif score < 0:
+            action = "sell"
+        else:
+            action = "hold"
+
+        confidence = min(100, int(abs(score) * 100))
+        target_weight = max(min(float(score), 1.0), -1.0)
+
+        return {
+            "symbol": symbol,
+            "action": action,
+            "confidence": confidence,
+            "target_weight": target_weight,
+            "thesis": "Fallback derived from quantitative alpha score in absence of GPT-5 output.",
+            "risk_notes": "LLM reasoning unavailable; rely on systematic risk controls.",
+            "analysis": [
+                "Alpha score magnitude used as proxy for conviction.",
+                "No qualitative news incorporated due to missing LLM response.",
+            ],
+        }

--- a/ov_trader/cli.py
+++ b/ov_trader/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 from pathlib import Path
 
+from .agents.decision_agent import DecisionAgent
 from .agents.execution_agent import ExecutionAgent
 from .agents.forecast_agent import ForecastAgent
 from .agents.news_agent import NewsSentimentAgent
@@ -28,9 +29,12 @@ def load_config(path: Path | None) -> TraderConfig:
 def build_orchestrator(config: TraderConfig) -> Orchestrator:
     news_agent = NewsSentimentAgent(config.llm_research)
     forecast_agent = ForecastAgent(config.data)
+    decision_agent = DecisionAgent(config.llm_research)
     portfolio_agent = PortfolioAgent(config.risk)
     execution_agent = ExecutionAgent(config.execution)
-    return Orchestrator([news_agent, forecast_agent, portfolio_agent, execution_agent])
+    return Orchestrator(
+        [news_agent, forecast_agent, decision_agent, portfolio_agent, execution_agent]
+    )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/ov_trader/strategies/alpha_mixture.py
+++ b/ov_trader/strategies/alpha_mixture.py
@@ -8,6 +8,10 @@ import pandas as pd
 class AlphaModel:
     """Placeholder alpha model that mixes multiple signals."""
 
+    def __init__(self) -> None:
+        self.latest_features: pd.DataFrame | None = None
+
+
     def generate_signals(self, dataset, feature_builder) -> pd.DataFrame:
         """Generate alpha scores for each instrument in the dataset.
 
@@ -21,6 +25,7 @@ class AlphaModel:
 
         raw = dataset.prepare("train")  # type: ignore[attr-defined]
         features = feature_builder.build(raw)
+        self.latest_features = features
         features["alpha"] = (
             0.4 * features["momentum_10"]
             + 0.3 * features["momentum_21"]

--- a/tests/test_decision_agent.py
+++ b/tests/test_decision_agent.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+
+from ov_trader.agents.base import AgentContext
+from ov_trader.agents.decision_agent import DecisionAgent
+from ov_trader.config import LLMConfig
+
+
+class _StubDecisionAgent(DecisionAgent):
+    def call_model(self, prompt: str) -> str:  # pragma: no cover - deterministic stub
+        payload = {
+            "symbol": "AAPL",
+            "action": "buy",
+            "confidence": 82,
+            "target_weight": 0.35,
+            "thesis": "Stub thesis",
+            "risk_notes": "Stub risks",
+            "analysis": [
+                "Alpha is strong.",
+                "News is positive.",
+            ],
+        }
+        return json.dumps(payload)
+
+
+class _ErrorDecisionAgent(DecisionAgent):
+    def call_model(self, prompt: str) -> str:  # pragma: no cover - deterministic failure
+        raise RuntimeError("LLM unavailable")
+
+
+def _build_context() -> AgentContext:
+    context = AgentContext(timestamp="2024-06-01T00:00:00Z")
+    context.market_state["alpha"] = {"AAPL": 0.42, "MSFT": 0.21, "TSLA": -0.15}
+    context.market_state["market_data"] = {
+        "AAPL": {
+            "as_of": "2024-05-31",
+            "close": 189.21,
+            "ma_10": 185.5,
+            "momentum_10": 0.034,
+        }
+    }
+    context.shared_memory["news_sentiment"] = "Overall bullish tone driven by product launch."
+    return context
+
+
+def test_decision_agent_builds_prompt_with_required_sections():
+    config = LLMConfig(provider="azure", model="gpt-5")
+    agent = DecisionAgent(config)
+    prompt = agent.build_prompt(_build_context())
+
+    assert "Qlib alpha signals" in prompt
+    assert "News and sentiment overview" in prompt
+    assert "Respond with a JSON object" in prompt
+    assert "AAPL" in prompt  # focus symbol should appear in prompt
+
+
+def test_decision_agent_parses_successful_model_response():
+    config = LLMConfig(provider="azure", model="gpt-5")
+    agent = _StubDecisionAgent(config)
+    context = _build_context()
+
+    updated = agent.run(context)
+    decision = updated.market_state["llm_decision"]
+
+    assert decision["action"] == "buy"
+    assert updated.shared_memory["llm_decision"]["parsed"]["symbol"] == "AAPL"
+
+
+def test_decision_agent_uses_fallback_when_model_fails():
+    config = LLMConfig(provider="azure", model="gpt-5")
+    agent = _ErrorDecisionAgent(config)
+    context = _build_context()
+
+    updated = agent.run(context)
+    fallback = updated.market_state["llm_decision"]
+
+    assert fallback["symbol"] == "AAPL"
+    assert updated.shared_memory["llm_decision"]["error"] == "LLM unavailable"


### PR DESCRIPTION
## Summary
- add Azure OpenAI support to the shared LLM agent base and capture richer market context from the forecast pipeline
- introduce a GPT-5 decision agent that synthesises Qlib alphas, price features, and news before advising portfolio actions
- update the orchestrator, documentation, and regression tests to exercise the new decision flow and its fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d19f727df8832bb596fc1b900e5f4b