### PR TITLE
Add web dashboard and API service for trading orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 __pycache__/
-*.pyc
-.pytest_cache/
-.DS_Store
+*.py[cod]
+*.egg-info/
+.env
+.venv/
+web/node_modules/
+web/.next/
+web/out/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ for LLM-powered research agents.
 - Configurable data ingestion via Qlib bundles for equities and crypto.
 - Backtesting harness using Qlib's `TopkDropoutStrategy`.
 - CLI entry point for running a full decision cycle.
+- FastAPI control plane with REST endpoints for triggering live cycles, inspecting
+  agent telemetry, and launching backtests.
+- Next.js dashboard for orchestrating trades, editing configuration, and
+  reviewing multi-agent outputs.
 
 ## Quick start
 
@@ -95,6 +99,39 @@ for LLM-powered research agents.
 
    The CLI logs the output of each agent and records cross-agent communication via
    the shared memory in :class:`~ov_trader.agents.base.AgentContext`.
+
+## Web dashboard
+
+The repository ships with a lightweight API server and Next.js front end for
+interactive experimentation.
+
+### Start the API service
+
+```bash
+uvicorn ov_trader.server.api:app --reload --port 8000
+```
+
+The FastAPI layer exposes endpoints such as `/dashboard`, `/runs`, `/config`, and
+`/backtests`.  These surface the same orchestration flow as the CLI while
+persisting run history and configuration updates in memory.
+
+### Start the Next.js client
+
+```bash
+cd web
+npm install
+npm run dev
+```
+
+The dashboard expects the API at `http://localhost:8000` by default.  Override
+the base URL via `NEXT_PUBLIC_API_BASE_URL` when deploying to another host.
+From the UI you can:
+
+- Trigger new agent cycles with optional natural-language guidance.
+- Launch backtests and inspect the resulting risk statistics.
+- Review per-agent transcripts alongside portfolio instructions.
+- Edit data, risk, execution, and LLM configuration values without touching
+  configuration files.
 
 ## Extending the system
 

--- a/ov_trader/agents/news_agent.py
+++ b/ov_trader/agents/news_agent.py
@@ -24,7 +24,7 @@ class NewsSentimentAgent(LLMEnabledAgent):
         aggregation service.
         """
 
-        now = dt.datetime.utcnow()
+        now = dt.datetime.now(dt.timezone.utc)
         return [
             f"[{now:%Y-%m-%d %H:%M}] Placeholder headline about macro environment",
             f"[{now:%Y-%m-%d %H:%M}] Placeholder crypto regulation update",
@@ -38,6 +38,6 @@ class NewsSentimentAgent(LLMEnabledAgent):
             "produce:\n"
             "1. A sentiment score between -1 (bearish) and +1 (bullish).\n"
             "2. Key catalysts relevant to equities and crypto.\n"
-            "3. A list of tickers that could be impacted."\n
+            "3. A list of tickers that could be impacted.\n"
             f"\nHeadlines:\n{joined}\n"
         )

--- a/ov_trader/server/__init__.py
+++ b/ov_trader/server/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI service exposing OV Trader orchestration and backtesting."""
+
+from .service import TradingService
+
+__all__ = ["TradingService"]

--- a/ov_trader/server/api.py
+++ b/ov_trader/server/api.py
@@ -1,0 +1,147 @@
+"""FastAPI application exposing OV Trader's orchestration endpoints."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.concurrency import run_in_threadpool
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, ConfigDict, Field
+
+from .service import TradingService
+
+
+class ConfigPayload(BaseModel):
+    """Payload used when updating configuration via the API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    data: Optional[Dict[str, Any]] = None
+    llm_research: Optional[Dict[str, Any]] = None
+    llm_forecasting: Optional[Dict[str, Any]] = None
+    execution: Optional[Dict[str, Any]] = None
+    risk: Optional[Dict[str, Any]] = None
+    backtest: Optional[Dict[str, Any]] = None
+
+
+class RunRequest(BaseModel):
+    """Request body for triggering a trading cycle."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    notes: Optional[str] = None
+    override_config: Optional[Dict[str, Any]] = Field(default=None, alias="overrideConfig")
+
+
+class BacktestRequest(BaseModel):
+    """Request body for launching a backtest."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    notes: Optional[str] = None
+    override_config: Optional[Dict[str, Any]] = Field(default=None, alias="overrideConfig")
+
+
+service = TradingService()
+
+app = FastAPI(title="OV Trader API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/", tags=["meta"])
+async def root() -> Dict[str, Any]:
+    """Return basic information about the API."""
+
+    return {
+        "name": "OV Trader API",
+        "version": "0.1.0",
+        "endpoints": ["/dashboard", "/runs", "/config", "/backtests"],
+    }
+
+
+@app.get("/health", tags=["meta"])
+async def health() -> Dict[str, str]:
+    """Health probe used for readiness checks."""
+
+    return {"status": "ok"}
+
+
+@app.get("/dashboard", tags=["dashboard"])
+async def dashboard() -> Dict[str, Any]:
+    """Return an aggregated dashboard payload."""
+
+    return service.get_dashboard()
+
+
+@app.get("/config", tags=["config"])
+async def get_config() -> Dict[str, Any]:
+    """Fetch the current configuration."""
+
+    return {"config": service.get_config()}
+
+
+@app.put("/config", tags=["config"])
+async def update_config(payload: ConfigPayload) -> Dict[str, Any]:
+    """Update persisted configuration values."""
+
+    data = payload.model_dump(exclude_none=True)
+    updated = service.update_config(data)
+    return {"config": updated}
+
+
+@app.get("/runs", tags=["trading"])
+async def list_runs(limit: int = 20) -> Dict[str, Any]:
+    """Return trading cycle history."""
+
+    return {"runs": service.list_runs(limit=limit)}
+
+
+@app.post("/runs", tags=["trading"])
+async def trigger_run(request: RunRequest) -> Dict[str, Any]:
+    """Trigger a new trading cycle."""
+
+    record = await run_in_threadpool(
+        lambda: service.run_cycle(
+            notes=request.notes,
+            override_config=request.override_config,
+        )
+    )
+    return {"run": record}
+
+
+@app.get("/runs/{run_id}", tags=["trading"])
+async def get_run(run_id: str) -> Dict[str, Any]:
+    """Retrieve a specific trading run by identifier."""
+
+    for run in service.list_runs():
+        if run["id"] == run_id:
+            return {"run": run}
+    raise HTTPException(status_code=404, detail="Run not found")
+
+
+@app.post("/backtests", tags=["backtesting"])
+async def trigger_backtest(request: BacktestRequest) -> Dict[str, Any]:
+    """Execute a backtest."""
+
+    record = await run_in_threadpool(
+        lambda: service.run_backtest(
+            notes=request.notes,
+            override_config=request.override_config,
+        )
+    )
+    return {"backtest": record}
+
+
+@app.get("/backtests", tags=["backtesting"])
+async def list_backtests(limit: int = 10) -> Dict[str, Any]:
+    """Return previously executed backtests."""
+
+    return {"backtests": service.list_backtests(limit=limit)}

--- a/ov_trader/server/service.py
+++ b/ov_trader/server/service.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from dataclasses import fields, is_dataclass
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency for serialisation helpers
+    import numpy as np
+except Exception:  # pragma: no cover - numpy is optional at runtime
+    np = None  # type: ignore
+
+try:  # pragma: no cover - pandas optional for timestamp conversion
+    import pandas as pd
+except Exception:  # pragma: no cover
+    pd = None  # type: ignore
+
+from ..agents.base import AgentContext
+from ..config import (
+    DEFAULT_CONFIG,
+    TraderConfig,
+    apply_config_update,
+    trader_config_to_dict,
+)
+from ..cli import build_orchestrator
+from ..utils.logging import configure_logging
+from ..backtesting.runner import Backtester
+
+
+logger = configure_logging()
+
+
+class TradingService:
+    """High level façade exposing orchestration and backtesting utilities."""
+
+    def __init__(self, config: TraderConfig | None = None) -> None:
+        self._config: TraderConfig = config or DEFAULT_CONFIG
+        self._history: List[Dict[str, Any]] = []
+        self._backtests: List[Dict[str, Any]] = []
+        self._last_context: AgentContext | None = None
+
+    # ------------------------------------------------------------------
+    # Configuration management
+    # ------------------------------------------------------------------
+    def get_config(self) -> Dict[str, Any]:
+        """Return the active configuration as a serialisable dictionary."""
+
+        return trader_config_to_dict(self._config)
+
+    def update_config(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Persist configuration changes and return the updated settings."""
+
+        self._config = apply_config_update(self._config, payload)
+        return self.get_config()
+
+    # ------------------------------------------------------------------
+    # Trading orchestration
+    # ------------------------------------------------------------------
+    def run_cycle(
+        self,
+        notes: str | None = None,
+        override_config: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Execute a full agent cycle and return a summary of the results."""
+
+        config = (
+            self._config
+            if override_config is None
+            else apply_config_update(self._config, override_config)
+        )
+
+        started = dt.datetime.now(dt.UTC)
+        status = "completed"
+        try:
+            orchestrator = build_orchestrator(config)
+            context = orchestrator.run_cycle()
+        except Exception as exc:  # pragma: no cover - defensive catch
+            logger.exception("Trading cycle failed: %s", exc)
+            status = "failed"
+            context = AgentContext(timestamp=started.isoformat())
+            context.shared_memory["orchestrator"] = {"error": str(exc)}
+        else:
+            self._last_context = context
+
+        record = self._context_to_record(
+            context=context,
+            status=status,
+            notes=notes,
+            config_snapshot=config,
+        )
+        record["duration"] = (dt.datetime.now(dt.UTC) - started).total_seconds()
+
+        self._history.insert(0, record)
+        self._history = self._history[:50]
+        return record
+
+    def list_runs(self, limit: int | None = None) -> List[Dict[str, Any]]:
+        """Return the most recent trading cycles."""
+
+        if limit is None:
+            return list(self._history)
+        return list(self._history[:limit])
+
+    def latest_run(self) -> Dict[str, Any] | None:
+        """Return the most recent run if available."""
+
+        return self._history[0] if self._history else None
+
+    # ------------------------------------------------------------------
+    # Backtesting
+    # ------------------------------------------------------------------
+    def run_backtest(
+        self,
+        notes: str | None = None,
+        override_config: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Execute a backtest using the configured data pipeline."""
+
+        config = (
+            self._config
+            if override_config is None
+            else apply_config_update(self._config, override_config)
+        )
+
+        started = dt.datetime.now(dt.UTC)
+        record: Dict[str, Any] = {
+            "id": str(uuid.uuid4()),
+            "timestamp": started.isoformat(),
+            "status": "completed",
+            "config_snapshot": trader_config_to_dict(config),
+        }
+        if notes:
+            record["notes"] = notes
+
+        backtester = Backtester(config.data, config.backtest)
+        try:
+            result = backtester.run()
+        except Exception as exc:  # pragma: no cover - optional deps may be missing
+            logger.exception("Backtest failed: %s", exc)
+            record["status"] = "failed"
+            record["error"] = str(exc)
+        else:
+            record["result"] = {
+                "analysis": self._serialise_value(result.analysis),
+                "report": self._serialise_value(result.report),
+            }
+
+        record["duration"] = (dt.datetime.now(dt.UTC) - started).total_seconds()
+        self._backtests.insert(0, record)
+        self._backtests = self._backtests[:20]
+        return record
+
+    def list_backtests(self, limit: int | None = None) -> List[Dict[str, Any]]:
+        """Return stored backtest results."""
+
+        if limit is None:
+            return list(self._backtests)
+        return list(self._backtests[:limit])
+
+    # ------------------------------------------------------------------
+    # Dashboard helpers
+    # ------------------------------------------------------------------
+    def get_dashboard(self) -> Dict[str, Any]:
+        """Return a combined payload suitable for dashboard rendering."""
+
+        return {
+            "config": self.get_config(),
+            "latest_run": self.latest_run(),
+            "runs": self.list_runs(limit=10),
+            "backtests": self.list_backtests(limit=5),
+            "metrics": {
+                "total_runs": len(self._history),
+                "total_backtests": len(self._backtests),
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _context_to_record(
+        self,
+        *,
+        context: AgentContext,
+        status: str,
+        notes: str | None,
+        config_snapshot: TraderConfig,
+    ) -> Dict[str, Any]:
+        shared = self._serialise_value(context.shared_memory)
+        market = self._serialise_value(context.market_state)
+        summary = self._build_summary(shared, market)
+
+        record: Dict[str, Any] = {
+            "id": str(uuid.uuid4()),
+            "timestamp": context.timestamp or dt.datetime.now(dt.UTC).isoformat(),
+            "status": status,
+            "shared_memory": shared,
+            "market_state": market,
+            "summary": summary,
+            "config_snapshot": trader_config_to_dict(config_snapshot),
+        }
+        if notes:
+            record["notes"] = notes
+        return record
+
+    def _build_summary(
+        self,
+        shared: Dict[str, Any],
+        market: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        decision = market.get("llm_decision")
+
+        llm_payload = shared.get("llm_decision")
+        if not decision and isinstance(llm_payload, dict):
+            decision = (
+                llm_payload.get("parsed")
+                or llm_payload.get("fallback")
+                or llm_payload.get("response")
+            )
+
+        orders = shared.get("portfolio_orders")
+        if not isinstance(orders, list):
+            orders = []
+
+        warnings: List[str] = []
+        errors: List[str] = []
+        for agent, payload in shared.items():
+            if isinstance(payload, dict):
+                if "warning" in payload:
+                    warnings.append(f"{agent}: {payload['warning']}")
+                if "error" in payload:
+                    errors.append(f"{agent}: {payload['error']}")
+
+        return {
+            "decision": decision,
+            "orders": orders,
+            "warnings": warnings,
+            "errors": errors,
+        }
+
+    def _serialise_value(self, value: Any) -> Any:
+        if is_dataclass(value):
+            result: Dict[str, Any] = {}
+            for field_info in fields(value):
+                result[field_info.name] = self._serialise_value(
+                    getattr(value, field_info.name)
+                )
+            return result
+
+        if isinstance(value, dict):
+            return {key: self._serialise_value(val) for key, val in value.items()}
+
+        if isinstance(value, (list, tuple, set)):
+            return [self._serialise_value(item) for item in value]
+
+        if isinstance(value, (dt.datetime, dt.date)):
+            return value.isoformat()
+
+        if pd is not None:
+            if isinstance(value, pd.Timestamp):
+                return value.isoformat()
+            if isinstance(value, pd.Series):  # pragma: no cover - optional dependency
+                return {
+                    key: self._serialise_value(val) for key, val in value.to_dict().items()
+                }
+            if isinstance(value, pd.Index):  # pragma: no cover
+                return [self._serialise_value(item) for item in value.tolist()]
+
+        if np is not None:
+            if isinstance(value, np.generic):  # pragma: no cover - depends on numpy
+                return value.item()
+            if isinstance(value, np.ndarray):  # pragma: no cover
+                return [self._serialise_value(item) for item in value.tolist()]
+
+        if isinstance(value, Decimal):
+            return float(value)
+
+        if hasattr(value, "isoformat"):
+            try:
+                return value.isoformat()
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+        return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ microsoft-qlib>=0.9.0
 pytrader @ git+https://github.com/jeanboydev/pytrader-api.git
 openai>=1.0
 requests>=2.31
+fastapi>=0.110
+uvicorn[standard]>=0.25
+pydantic>=2.6

--- a/tests/test_trading_service.py
+++ b/tests/test_trading_service.py
@@ -1,0 +1,35 @@
+from ov_trader.server import TradingService
+
+
+def test_trading_service_updates_config():
+    service = TradingService()
+    updated = service.update_config({"risk": {"max_leverage": 3.0}})
+    assert updated["risk"]["max_leverage"] == 3.0
+
+
+def test_trading_service_run_cycle_creates_history():
+    service = TradingService()
+    result = service.run_cycle(notes="unit-test")
+
+    assert result["id"]
+    assert "shared_memory" in result
+    assert result["status"] in {"completed", "failed"}
+    history = service.list_runs()
+    assert history and history[0]["id"] == result["id"]
+
+
+def test_trading_service_backtest_handles_missing_dependencies():
+    service = TradingService()
+    record = service.run_backtest(notes="unit-test")
+
+    assert record["status"] in {"completed", "failed"}
+    assert "config_snapshot" in record
+
+
+def test_dashboard_payload_contains_expected_keys():
+    service = TradingService()
+    service.run_cycle()
+    service.run_backtest()
+    payload = service.get_dashboard()
+
+    assert {"config", "latest_run", "runs", "backtests", "metrics"} <= payload.keys()

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,0 +1,32 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 min-h-screen;
+  font-family: 'Inter', sans-serif;
+}
+
+main {
+  @apply max-w-6xl mx-auto px-6 py-8;
+}
+
+a {
+  @apply text-brand hover:text-brand-light transition-colors;
+}
+
+.card {
+  @apply rounded-xl border border-slate-800 bg-slate-900/70 p-6 shadow-lg shadow-black/30;
+}
+
+.card-title {
+  @apply text-lg font-semibold text-slate-100;
+}
+
+.muted {
+  @apply text-slate-400;
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "OV Trader Control Center",
+  description: "Dashboard for orchestrating OV Trader research, execution, and backtesting.",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,0 +1,7 @@
+import DashboardClient from "@/components/DashboardClient";
+import { fetchDashboard } from "@/lib/api";
+
+export default async function Page() {
+  const data = await fetchDashboard();
+  return <DashboardClient initialData={data} />;
+}

--- a/web/components/AgentInsights.tsx
+++ b/web/components/AgentInsights.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { RunRecord, Order, Decision } from "@/lib/types";
+
+interface AgentInsightsProps {
+  latestRun: RunRecord | null;
+  onRefresh: () => Promise<unknown> | void;
+}
+
+function isDecision(value: unknown): value is Decision {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function formatOrder(order: Order, index: number): string {
+  const quantityValue = Number(order.quantity ?? 0);
+  const quantity = Number.isFinite(quantityValue) ? quantityValue.toFixed(4) : "0";
+  return `${index + 1}. ${order.side?.toUpperCase() ?? "HOLD"} ${order.symbol} (${quantity})`;
+}
+
+function renderAnalysis(analysis: unknown): string[] {
+  if (Array.isArray(analysis)) {
+    return analysis.map((item) => String(item));
+  }
+  if (typeof analysis === "string") {
+    return [analysis];
+  }
+  return [];
+}
+
+export default function AgentInsights({ latestRun, onRefresh }: AgentInsightsProps) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const decision = useMemo(() => {
+    if (!latestRun) {
+      return null;
+    }
+    const rawDecision = latestRun.summary?.decision;
+    if (isDecision(rawDecision)) {
+      return rawDecision;
+    }
+    if (typeof rawDecision === "string") {
+      try {
+        const parsed = JSON.parse(rawDecision) as Decision;
+        if (isDecision(parsed)) {
+          return parsed;
+        }
+      } catch (error) {
+        return { thesis: rawDecision } as Decision;
+      }
+    }
+    return null;
+  }, [latestRun]);
+
+  const orders = useMemo(() => latestRun?.summary?.orders ?? [], [latestRun?.summary?.orders]);
+
+  if (!latestRun) {
+    return (
+      <section className="card">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="card-title">Latest agent synthesis</h2>
+            <p className="muted text-sm">Trigger a trading cycle to populate the dashboard.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onRefresh?.()}
+            className="rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-200 hover:border-brand"
+          >
+            Refresh
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const sharedEntries = Object.entries(latestRun.shared_memory);
+
+  return (
+    <section className="card space-y-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="card-title">Latest agent synthesis</h2>
+          <p className="muted text-sm">
+            Cycle ID {latestRun.id} · {new Date(latestRun.timestamp).toLocaleString()} · Status: {latestRun.status}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onRefresh?.()}
+          className="rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-200 hover:border-brand"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold text-slate-300">Decision summary</h3>
+          {decision ? (
+            <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4 text-sm text-slate-100">
+              <p className="font-semibold text-slate-200">
+                {decision.symbol ?? "N/A"} · {decision.action?.toUpperCase() ?? "HOLD"}
+              </p>
+              <p className="muted">
+                Confidence: {decision.confidence ?? "--"} · Target weight: {decision.target_weight ?? "--"}
+              </p>
+              {decision.thesis && <p className="mt-2 text-slate-200">{decision.thesis}</p>}
+              {decision.risk_notes && (
+                <p className="mt-2 text-xs text-orange-300">Risk: {decision.risk_notes}</p>
+              )}
+              {decision.analysis && (
+                <ul className="mt-3 list-disc space-y-1 pl-4 text-xs text-slate-300">
+                  {renderAnalysis(decision.analysis).map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ) : (
+            <p className="rounded-lg border border-dashed border-slate-800 p-4 text-sm text-slate-400">
+              The decision agent did not return a structured recommendation.
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold text-slate-300">Portfolio instructions</h3>
+          {orders.length > 0 ? (
+            <ul className="rounded-lg border border-slate-800 bg-slate-950/60 p-4 text-sm text-slate-100">
+              {orders.map((order, index) => (
+                <li key={`${order.symbol}-${index}`}>{formatOrder(order, index)}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="rounded-lg border border-dashed border-slate-800 p-4 text-sm text-slate-400">
+              No executable orders were generated for this cycle.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold text-slate-300">Agent transcripts</h3>
+        <div className="divide-y divide-slate-800 rounded-lg border border-slate-800 bg-slate-950/40">
+          {sharedEntries.map(([agent, payload]) => {
+            const isOpen = expanded === agent;
+            return (
+              <div key={agent} className="p-4">
+                <button
+                  type="button"
+                  onClick={() => setExpanded(isOpen ? null : agent)}
+                  className="flex w-full items-center justify-between text-left text-sm font-semibold text-slate-200"
+                >
+                  <span>{agent}</span>
+                  <span className="text-xs text-slate-400">{isOpen ? "Hide" : "Show"}</span>
+                </button>
+                {isOpen && (
+                  <pre className="mt-3 max-h-64 overflow-y-auto rounded bg-slate-900/80 p-3 text-xs text-slate-200">
+                    {JSON.stringify(payload, null, 2)}
+                  </pre>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/BacktestPanel.tsx
+++ b/web/components/BacktestPanel.tsx
@@ -1,0 +1,92 @@
+import { BacktestRecord } from "@/lib/types";
+
+interface BacktestPanelProps {
+  backtests: BacktestRecord[];
+}
+
+function renderMetrics(record: BacktestRecord): Array<[string, string]> {
+  const metrics: Array<[string, string]> = [];
+  const analysis = (record.result?.analysis ?? {}) as Record<string, unknown>;
+  const keys = Object.keys(analysis);
+  for (const key of keys.slice(0, 4)) {
+    const value = analysis[key];
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === "number") {
+      metrics.push([key, value.toFixed(4)]);
+    } else {
+      metrics.push([key, String(value)]);
+    }
+  }
+  return metrics;
+}
+
+export default function BacktestPanel({ backtests }: BacktestPanelProps) {
+  if (!backtests || backtests.length === 0) {
+    return (
+      <section className="card h-full">
+        <h2 className="card-title">Backtesting</h2>
+        <p className="muted text-sm">Run a backtest to populate performance analytics.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="card h-full space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="card-title">Backtesting</h2>
+        <span className="text-xs uppercase tracking-wide text-slate-500">
+          Showing latest {Math.min(5, backtests.length)}
+        </span>
+      </div>
+      <ul className="space-y-3 text-sm">
+        {backtests.slice(0, 5).map((backtest) => {
+          const metrics = renderMetrics(backtest);
+          return (
+            <li key={backtest.id} className="rounded-lg border border-slate-800 bg-slate-950/50 p-4">
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="font-semibold text-slate-100">
+                    {new Date(backtest.timestamp).toLocaleString()}
+                  </p>
+                  <p className="text-xs text-slate-400">Backtest ID {backtest.id}</p>
+                </div>
+                <span
+                  className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                    backtest.status === "completed"
+                      ? "bg-emerald-500/10 text-emerald-300"
+                      : "bg-orange-500/10 text-orange-300"
+                  }`}
+                >
+                  {backtest.status}
+                </span>
+              </div>
+              {backtest.error && (
+                <p className="mt-2 text-xs text-orange-300">{backtest.error}</p>
+              )}
+              {metrics.length > 0 && (
+                <div className="mt-3 grid grid-cols-2 gap-3 text-xs text-slate-200">
+                  {metrics.map(([key, value]) => (
+                    <div key={key}>
+                      <p className="uppercase text-slate-500">{key}</p>
+                      <p>{value}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {backtest.result?.report && (
+                <details className="mt-3 text-xs">
+                  <summary className="cursor-pointer text-slate-400">View raw report</summary>
+                  <pre className="mt-2 max-h-48 overflow-y-auto rounded bg-slate-900/80 p-3">
+                    {JSON.stringify(backtest.result.report, null, 2)}
+                  </pre>
+                </details>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/web/components/ConfigForm.tsx
+++ b/web/components/ConfigForm.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+import { TraderConfig } from "@/lib/types";
+
+interface ConfigFormProps {
+  initialConfig: TraderConfig;
+  onSubmit: (config: TraderConfig) => void;
+  busy?: boolean;
+}
+
+function cloneConfig(config: TraderConfig): TraderConfig {
+  return JSON.parse(JSON.stringify(config)) as TraderConfig;
+}
+
+export default function ConfigForm({
+  initialConfig,
+  onSubmit,
+  busy = false,
+}: ConfigFormProps) {
+  const [formState, setFormState] = useState<TraderConfig>(cloneConfig(initialConfig));
+
+  useEffect(() => {
+    setFormState(cloneConfig(initialConfig));
+  }, [initialConfig]);
+
+  const instrumentString = useMemo(
+    () => formState.data.instruments.join(", "),
+    [formState.data.instruments],
+  );
+
+  const handleFieldChange = (path: string, value: unknown) => {
+    setFormState((prev) => {
+      const next = cloneConfig(prev);
+      const segments = path.split(".");
+      let cursor: Record<string, unknown> = next as unknown as Record<string, unknown>;
+      for (const segment of segments.slice(0, -1)) {
+        if (cursor[segment] === undefined || cursor[segment] === null) {
+          cursor[segment] = {};
+        }
+        cursor = cursor[segment] as Record<string, unknown>;
+      }
+      cursor[segments[segments.length - 1]] = value;
+      return next;
+    });
+  };
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    onSubmit(formState);
+  };
+
+  return (
+    <section className="card space-y-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="card-title">Configuration</h2>
+          <p className="muted text-sm">
+            Adjust data sources, LLM preferences, execution connectivity, and risk tolerances. Changes apply to subsequent runs.
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => setFormState(cloneConfig(initialConfig))}
+          className="rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-200 hover:border-brand"
+        >
+          Reset
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="grid gap-6 lg:grid-cols-2">
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold text-slate-300">Data & research LLM</legend>
+          <label className="block text-sm">
+            <span className="text-slate-400">Qlib root</span>
+            <input
+              type="text"
+              value={formState.data.qlib_root}
+              onChange={(event) => handleFieldChange("data.qlib_root", event.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-slate-400">Calendar</span>
+            <input
+              type="text"
+              value={formState.data.calendar}
+              onChange={(event) => handleFieldChange("data.calendar", event.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-slate-400">Instruments</span>
+            <input
+              type="text"
+              value={instrumentString}
+              onChange={(event) =>
+                handleFieldChange(
+                  "data.instruments",
+                  event.target.value
+                    .split(",")
+                    .map((item) => item.trim())
+                    .filter(Boolean),
+                )
+              }
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+            />
+          </label>
+          <div className="grid grid-cols-2 gap-4">
+            <label className="block text-sm">
+              <span className="text-slate-400">Start</span>
+              <input
+                type="text"
+                value={formState.data.start_time}
+                onChange={(event) => handleFieldChange("data.start_time", event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-400">End</span>
+              <input
+                type="text"
+                value={formState.data.end_time ?? ""}
+                onChange={(event) => handleFieldChange("data.end_time", event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              />
+            </label>
+          </div>
+          <label className="block text-sm">
+            <span className="text-slate-400">LLM provider</span>
+            <input
+              type="text"
+              value={formState.llm_research.provider}
+              onChange={(event) => handleFieldChange("llm_research.provider", event.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-slate-400">LLM model</span>
+            <input
+              type="text"
+              value={formState.llm_research.model}
+              onChange={(event) => handleFieldChange("llm_research.model", event.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+            />
+          </label>
+        </fieldset>
+
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold text-slate-300">Risk & execution</legend>
+          <div className="grid grid-cols-2 gap-4">
+            <label className="block text-sm">
+              <span className="text-slate-400">Max leverage</span>
+              <input
+                type="number"
+                step="0.1"
+                value={formState.risk.max_leverage}
+                onChange={(event) => handleFieldChange("risk.max_leverage", Number(event.target.value))}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-400">Max drawdown</span>
+              <input
+                type="number"
+                step="0.01"
+                value={formState.risk.max_drawdown}
+                onChange={(event) => handleFieldChange("risk.max_drawdown", Number(event.target.value))}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-400">Position limit</span>
+              <input
+                type="number"
+                step="0.01"
+                value={formState.risk.position_limit}
+                onChange={(event) => handleFieldChange("risk.position_limit", Number(event.target.value))}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-400">Stop loss %</span>
+              <input
+                type="number"
+                step="0.01"
+                value={formState.risk.stop_loss_pct}
+                onChange={(event) => handleFieldChange("risk.stop_loss_pct", Number(event.target.value))}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-400">Take profit %</span>
+              <input
+                type="number"
+                step="0.01"
+                value={formState.risk.take_profit_pct}
+                onChange={(event) => handleFieldChange("risk.take_profit_pct", Number(event.target.value))}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-400">Rebalance frequency</span>
+              <input
+                type="text"
+                value={formState.risk.rebalance_frequency}
+                onChange={(event) => handleFieldChange("risk.rebalance_frequency", event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              />
+            </label>
+          </div>
+
+          <label className="block text-sm">
+            <span className="text-slate-400">Execution host</span>
+            <input
+              type="text"
+              value={formState.execution.server_host}
+              onChange={(event) => handleFieldChange("execution.server_host", event.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-slate-400">Execution port</span>
+            <input
+              type="number"
+              value={formState.execution.server_port}
+              onChange={(event) => handleFieldChange("execution.server_port", Number(event.target.value))}
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-slate-400">Client ID</span>
+            <input
+              type="text"
+              value={formState.execution.client_id}
+              onChange={(event) => handleFieldChange("execution.client_id", event.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-slate-400">Accounts</span>
+            <input
+              type="text"
+              value={formState.execution.account_aliases.join(", ")}
+              onChange={(event) =>
+                handleFieldChange(
+                  "execution.account_aliases",
+                  event.target.value
+                    .split(",")
+                    .map((item) => item.trim())
+                    .filter(Boolean),
+                )
+              }
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+            />
+          </label>
+        </fieldset>
+
+        <fieldset className="space-y-4 lg:col-span-2">
+          <legend className="text-sm font-semibold text-slate-300">Backtest defaults</legend>
+          <div className="grid grid-cols-2 gap-4">
+            <label className="block text-sm">
+              <span className="text-slate-400">Benchmark</span>
+              <input
+                type="text"
+                value={formState.backtest.benchmark}
+                onChange={(event) => handleFieldChange("backtest.benchmark", event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-400">Start</span>
+              <input
+                type="text"
+                value={formState.backtest.start_time}
+                onChange={(event) => handleFieldChange("backtest.start_time", event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-400">End</span>
+              <input
+                type="text"
+                value={formState.backtest.end_time}
+                onChange={(event) => handleFieldChange("backtest.end_time", event.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-400">Verbose</span>
+              <select
+                value={formState.backtest.verbose ? "true" : "false"}
+                onChange={(event) => handleFieldChange("backtest.verbose", event.target.value === "true")}
+                className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+              >
+                <option value="true">Enabled</option>
+                <option value="false">Disabled</option>
+              </select>
+            </label>
+          </div>
+          <label className="block text-sm">
+            <span className="text-slate-400">Starting cash</span>
+            <input
+              type="number"
+              value={formState.backtest.account.cash ?? 0}
+              onChange={(event) =>
+                handleFieldChange("backtest.account", {
+                  ...formState.backtest.account,
+                  cash: Number(event.target.value),
+                })
+              }
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+            />
+          </label>
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={busy}
+              className="rounded-lg bg-brand px-5 py-2 text-sm font-semibold text-white transition hover:bg-brand-light disabled:opacity-50"
+            >
+              {busy ? "Saving..." : "Save configuration"}
+            </button>
+          </div>
+        </fieldset>
+      </form>
+    </section>
+  );
+}

--- a/web/components/DashboardClient.tsx
+++ b/web/components/DashboardClient.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useCallback, useMemo, useState, useTransition } from "react";
+
+import {
+  refreshDashboard,
+  runTradingCycle,
+  saveConfig,
+  startBacktest,
+} from "@/lib/api";
+import { DashboardData, TraderConfig } from "@/lib/types";
+import AgentInsights from "./AgentInsights";
+import BacktestPanel from "./BacktestPanel";
+import ConfigForm from "./ConfigForm";
+import RunHistory from "./RunHistory";
+import TradingControls from "./TradingControls";
+
+interface DashboardClientProps {
+  initialData: DashboardData;
+}
+
+export default function DashboardClient({ initialData }: DashboardClientProps) {
+  const [data, setData] = useState<DashboardData>(initialData);
+  const [statusMessage, setStatusMessage] = useState<string | null>(
+    initialData.error ?? null,
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const metrics = useMemo(() => data.metrics ?? { total_runs: 0, total_backtests: 0 }, [data.metrics]);
+
+  const refresh = useCallback(async () => {
+    const next = await refreshDashboard();
+    setData(next);
+    return next;
+  }, []);
+
+  const handleRun = useCallback(
+    (notes?: string) => {
+      startTransition(async () => {
+        setStatusMessage("Executing trading cycle...");
+        try {
+          await runTradingCycle(notes ? { notes } : undefined);
+          const next = await refresh();
+          const timestamp = next.latest_run?.timestamp
+            ? new Date(next.latest_run.timestamp).toLocaleString()
+            : new Date().toLocaleString();
+          setStatusMessage(`Trading cycle completed at ${timestamp}.`);
+        } catch (error) {
+          setStatusMessage(`Trading cycle failed: ${(error as Error).message}`);
+        }
+      });
+    },
+    [refresh],
+  );
+
+  const handleBacktest = useCallback(
+    (notes?: string) => {
+      startTransition(async () => {
+        setStatusMessage("Running backtest...");
+        try {
+          await startBacktest(notes ? { notes } : undefined);
+          await refresh();
+          setStatusMessage("Backtest finished.");
+        } catch (error) {
+          setStatusMessage(`Backtest failed: ${(error as Error).message}`);
+        }
+      });
+    },
+    [refresh],
+  );
+
+  const handleConfigSave = useCallback(
+    (config: TraderConfig) => {
+      startTransition(async () => {
+        setStatusMessage("Saving configuration...");
+        try {
+          const updated = await saveConfig(config);
+          setData((prev) => ({ ...prev, config: updated }));
+          setStatusMessage("Configuration saved.");
+        } catch (error) {
+          setStatusMessage(`Configuration update failed: ${(error as Error).message}`);
+        }
+      });
+    },
+    [],
+  );
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">OV Trader Command Center</h1>
+          <p className="muted">
+            Monitor agent insights, trigger fresh trading cycles, and validate strategies via backtests.
+          </p>
+        </div>
+        <div className="text-sm text-right text-slate-400">
+          <p>Total cycles: {metrics.total_runs}</p>
+          <p>Backtests: {metrics.total_backtests}</p>
+        </div>
+      </header>
+
+      {statusMessage && (
+        <div className="card border-brand/40 bg-brand/10 text-sm">
+          {statusMessage}
+        </div>
+      )}
+
+      <TradingControls
+        busy={isPending}
+        onRun={handleRun}
+        onBacktest={handleBacktest}
+        onRefresh={() => {
+          startTransition(async () => {
+            setStatusMessage("Refreshing dashboard...");
+            try {
+              await refresh();
+              setStatusMessage("Dashboard up to date.");
+            } catch (error) {
+              setStatusMessage(`Refresh failed: ${(error as Error).message}`);
+            }
+          });
+        }}
+      />
+
+      <AgentInsights latestRun={data.latest_run} onRefresh={refresh} />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <RunHistory runs={data.runs} />
+        <BacktestPanel backtests={data.backtests} />
+      </div>
+
+      <ConfigForm
+        busy={isPending}
+        initialConfig={data.config}
+        onSubmit={handleConfigSave}
+      />
+    </div>
+  );
+}

--- a/web/components/RunHistory.tsx
+++ b/web/components/RunHistory.tsx
@@ -1,0 +1,84 @@
+import { RunRecord, Decision } from "@/lib/types";
+
+interface RunHistoryProps {
+  runs: RunRecord[];
+}
+
+function extractAction(summaryDecision: RunRecord["summary"]["decision"]): string {
+  if (!summaryDecision) {
+    return "--";
+  }
+  if (typeof summaryDecision === "string") {
+    return summaryDecision;
+  }
+  const decision = summaryDecision as Decision;
+  return decision.action ? decision.action.toUpperCase() : "--";
+}
+
+export default function RunHistory({ runs }: RunHistoryProps) {
+  if (!runs || runs.length === 0) {
+    return (
+      <section className="card h-full">
+        <h2 className="card-title">Recent trading cycles</h2>
+        <p className="muted text-sm">No live cycles recorded yet.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="card h-full space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="card-title">Recent trading cycles</h2>
+        <span className="text-xs uppercase tracking-wide text-slate-500">
+          Showing latest {Math.min(8, runs.length)}
+        </span>
+      </div>
+      <ul className="space-y-3 text-sm">
+        {runs.slice(0, 8).map((run) => (
+          <li key={run.id} className="rounded-lg border border-slate-800 bg-slate-950/50 p-4">
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-semibold text-slate-100">
+                  {new Date(run.timestamp).toLocaleString()}
+                </p>
+                <p className="text-xs text-slate-400">Cycle ID {run.id}</p>
+              </div>
+              <span
+                className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                  run.status === "completed"
+                    ? "bg-emerald-500/10 text-emerald-300"
+                    : "bg-orange-500/10 text-orange-300"
+                }`}
+              >
+                {run.status}
+              </span>
+            </div>
+            <div className="mt-3 grid gap-3 lg:grid-cols-2">
+              <div>
+                <p className="text-xs uppercase text-slate-500">Action</p>
+                <p className="text-slate-200">{extractAction(run.summary.decision)}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-slate-500">Orders</p>
+                <p className="text-slate-200">{run.summary.orders.length}</p>
+              </div>
+            </div>
+            {(run.summary.warnings.length > 0 || run.summary.errors.length > 0) && (
+              <details className="mt-3">
+                <summary className="cursor-pointer text-xs text-orange-300">Diagnostics</summary>
+                <ul className="mt-2 list-disc space-y-1 pl-4 text-xs text-orange-200">
+                  {run.summary.warnings.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                  {run.summary.errors.map((error) => (
+                    <li key={error}>{error}</li>
+                  ))}
+                </ul>
+              </details>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/web/components/TradingControls.tsx
+++ b/web/components/TradingControls.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+
+interface TradingControlsProps {
+  busy?: boolean;
+  onRun: (notes?: string) => void;
+  onBacktest: (notes?: string) => void;
+  onRefresh: () => void;
+}
+
+export default function TradingControls({
+  busy = false,
+  onRun,
+  onBacktest,
+  onRefresh,
+}: TradingControlsProps) {
+  const [runNotes, setRunNotes] = useState<string>("");
+  const [backtestNotes, setBacktestNotes] = useState<string>("");
+
+  return (
+    <section className="card space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="card-title">Live trading orchestration</h2>
+          <p className="muted text-sm">
+            Launch the full multi-agent decision cycle and capture optional guidance for the LLM decision layer.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={busy}
+          className="rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-200 transition hover:border-brand"
+        >
+          Refresh data
+        </button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-3">
+          <label className="block text-sm font-medium text-slate-300" htmlFor="run-notes">
+            Trading cycle notes
+          </label>
+          <textarea
+            id="run-notes"
+            value={runNotes}
+            onChange={(event) => setRunNotes(event.target.value)}
+            placeholder="E.g. emphasise large-cap tech or reduce crypto exposure."
+            className="h-24 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-3 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+          />
+          <button
+            type="button"
+            onClick={() => onRun(runNotes.trim() || undefined)}
+            disabled={busy}
+            className="w-full rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-light disabled:opacity-50"
+          >
+            {busy ? "Running..." : "Run trading cycle"}
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          <label className="block text-sm font-medium text-slate-300" htmlFor="backtest-notes">
+            Backtest memo
+          </label>
+          <textarea
+            id="backtest-notes"
+            value={backtestNotes}
+            onChange={(event) => setBacktestNotes(event.target.value)}
+            placeholder="E.g. evaluate 2020-2022 drawdowns or tweak factor blend."
+            className="h-24 w-full rounded-lg border border-slate-800 bg-slate-950/60 p-3 text-sm text-slate-100 outline-none focus:border-brand focus:ring-1 focus:ring-brand"
+          />
+          <button
+            type="button"
+            onClick={() => onBacktest(backtestNotes.trim() || undefined)}
+            disabled={busy}
+            className="w-full rounded-lg border border-brand px-4 py-2 text-sm font-semibold text-brand transition hover:bg-brand/10 disabled:opacity-50"
+          >
+            {busy ? "Processing..." : "Run backtest"}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,0 +1,122 @@
+import { DashboardData, RunRecord, BacktestRecord, TraderConfig } from "./types";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+
+const fallbackConfig: TraderConfig = {
+  data: {
+    qlib_root: "",
+    calendar: "USNYSE",
+    instruments: [],
+    start_time: "",
+    end_time: "",
+    auto_update: false,
+  },
+  llm_research: {
+    provider: "",
+    model: "",
+    temperature: 0.2,
+    max_tokens: 0,
+    extra: {},
+  },
+  llm_forecasting: null,
+  execution: {
+    server_host: "",
+    server_port: 0,
+    client_id: "",
+    account_aliases: [],
+  },
+  risk: {
+    max_leverage: 0,
+    max_drawdown: 0,
+    position_limit: 0,
+    stop_loss_pct: 0,
+    take_profit_pct: 0,
+    rebalance_frequency: "",
+  },
+  backtest: {
+    benchmark: "",
+    start_time: "",
+    end_time: "",
+    account: {},
+    verbose: false,
+  },
+};
+
+function cloneConfig(config: TraderConfig): TraderConfig {
+  return JSON.parse(JSON.stringify(config)) as TraderConfig;
+}
+
+function createEmptyDashboard(error?: string): DashboardData {
+  return {
+    config: cloneConfig(fallbackConfig),
+    latest_run: null,
+    runs: [],
+    backtests: [],
+    metrics: { total_runs: 0, total_backtests: 0 },
+    error,
+  };
+}
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(text || response.statusText);
+  }
+  return text ? (JSON.parse(text) as T) : ({} as T);
+}
+
+export async function fetchDashboard(): Promise<DashboardData> {
+  try {
+    const response = await fetch(`${API_BASE}/dashboard`, {
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) {
+      throw new Error(`Dashboard request failed: ${response.status}`);
+    }
+    const data = (await response.json()) as DashboardData;
+    return data;
+  } catch (error) {
+    return createEmptyDashboard((error as Error).message);
+  }
+}
+
+export async function runTradingCycle(body?: {
+  notes?: string;
+  overrideConfig?: Partial<TraderConfig>;
+}): Promise<RunRecord> {
+  const response = await fetch(`${API_BASE}/runs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+  const data = await parseResponse<{ run: RunRecord }>(response);
+  return data.run;
+}
+
+export async function startBacktest(body?: {
+  notes?: string;
+  overrideConfig?: Partial<TraderConfig>;
+}): Promise<BacktestRecord> {
+  const response = await fetch(`${API_BASE}/backtests`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+  const data = await parseResponse<{ backtest: BacktestRecord }>(response);
+  return data.backtest;
+}
+
+export async function saveConfig(config: TraderConfig): Promise<DashboardData["config"]> {
+  const response = await fetch(`${API_BASE}/config`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(config),
+  });
+  const data = await parseResponse<{ config: TraderConfig }>(response);
+  return data.config;
+}
+
+export async function refreshDashboard(): Promise<DashboardData> {
+  return fetchDashboard();
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1,0 +1,117 @@
+export interface DataConfig {
+  qlib_root: string;
+  calendar: string;
+  instruments: string[];
+  start_time: string;
+  end_time?: string | null;
+  auto_update?: boolean;
+}
+
+export interface LLMConfig {
+  provider: string;
+  model: string;
+  api_key?: string | null;
+  temperature?: number;
+  max_tokens?: number;
+  extra?: Record<string, unknown>;
+}
+
+export interface ExecutionConfig {
+  server_host: string;
+  server_port: number;
+  client_id: string;
+  account_aliases: string[];
+}
+
+export interface RiskConfig {
+  max_leverage: number;
+  max_drawdown: number;
+  position_limit: number;
+  stop_loss_pct: number;
+  take_profit_pct: number;
+  rebalance_frequency: string;
+}
+
+export interface BacktestConfig {
+  benchmark: string;
+  start_time: string;
+  end_time: string;
+  account: Record<string, number>;
+  verbose: boolean;
+}
+
+export interface TraderConfig {
+  data: DataConfig;
+  llm_research: LLMConfig;
+  llm_forecasting?: LLMConfig | null;
+  execution: ExecutionConfig;
+  risk: RiskConfig;
+  backtest: BacktestConfig;
+}
+
+export interface Order {
+  symbol: string;
+  quantity: number;
+  side: string;
+  order_type?: string;
+  price?: number | null;
+}
+
+export interface Decision {
+  symbol?: string;
+  action?: string;
+  confidence?: number;
+  target_weight?: number;
+  thesis?: string;
+  risk_notes?: string;
+  analysis?: unknown;
+}
+
+export interface RunSummary {
+  decision?: Decision | string | null;
+  orders: Order[];
+  warnings: string[];
+  errors: string[];
+}
+
+export interface RunRecord {
+  id: string;
+  timestamp: string;
+  status: string;
+  summary: RunSummary;
+  shared_memory: Record<string, unknown>;
+  market_state: Record<string, unknown>;
+  duration?: number;
+  notes?: string;
+  config_snapshot: TraderConfig;
+}
+
+export interface BacktestResultPayload {
+  analysis?: Record<string, unknown>;
+  report?: Record<string, unknown>;
+}
+
+export interface BacktestRecord {
+  id: string;
+  timestamp: string;
+  status: string;
+  result?: BacktestResultPayload;
+  error?: string;
+  notes?: string;
+  duration?: number;
+  config_snapshot: TraderConfig;
+}
+
+export interface DashboardMetrics {
+  total_runs: number;
+  total_backtests: number;
+}
+
+export interface DashboardData {
+  config: TraderConfig;
+  latest_run: RunRecord | null;
+  runs: RunRecord[];
+  backtests: BacktestRecord[];
+  metrics: DashboardMetrics;
+  error?: string;
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: true,
+  },
+};
+
+export default nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "ov-trader-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.17",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.4",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.5"
+  }
+}

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./lib/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: "#2563eb",
+          light: "#3b82f6",
+          dark: "#1d4ed8",
+        },
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a FastAPI service that wraps the multi-agent orchestrator, handles configuration updates, and exposes dashboard-friendly payloads
- expand configuration utilities to support serialisation/merging and add pytest coverage for the trading service workflow
- scaffold a Next.js command center that triggers runs/backtests, surfaces agent transcripts, and documents the web workflow in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a831ec28832b9c7ea799ff99327c