### PR TITLE
Add shared environment support and PowerShell start script

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,20 @@
+# Shared environment configuration for OV Trader
+# Values defined here are loaded by both the FastAPI backend and the Next.js frontend.
+# Replace placeholder values (e.g. API keys) with your own secrets for local development.
+
+# Backend API host/port
+OV_TRADER_API_HOST=127.0.0.1
+OV_TRADER_API_PORT=8000
+
+# Frontend dev server host/port
+OV_TRADER_WEB_HOST=127.0.0.1
+OV_TRADER_WEB_PORT=3000
+
+# Public URL used by the frontend to call the backend API
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+
+# Optional provider credentials used by LLM-enabled agents
+OPENAI_API_KEY=your-openai-api-key
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_API_VERSION=2024-02-15-preview

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 __pycache__/
 *.py[cod]
+.env.local
+.env.development.local
+.env.production.local
+.env.test.local
 *.egg-info/
-.env
 .venv/
 web/node_modules/
 web/.next/

--- a/README.md
+++ b/README.md
@@ -105,6 +105,24 @@ for LLM-powered research agents.
 The repository ships with a lightweight API server and Next.js front end for
 interactive experimentation.
 
+### Shared environment configuration
+
+A repository level `.env` file is provided so that both the FastAPI backend and
+the Next.js frontend read the same configuration.  Update the placeholder
+values (for example the API keys) before running the stack locally.
+
+### Quick start (PowerShell)
+
+On Windows you can start both services with a single command:
+
+```powershell
+./start.ps1
+```
+
+The script loads variables from `.env`, ensures the required tools are
+available, and watches both processes.  Use `-NoBackend` or `-NoFrontend` to
+skip either service.
+
 ### Start the API service
 
 ```bash

--- a/ov_trader/__init__.py
+++ b/ov_trader/__init__.py
@@ -1,5 +1,34 @@
 """Core package for the OV Trader multi-agent trading system."""
-from importlib.metadata import version, PackageNotFoundError
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+import os
+
+
+def _load_root_env() -> None:
+    """Load variables from the repository level ``.env`` file if present."""
+
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if not env_path.exists():  # pragma: no cover - optional convenience for devs
+        return
+
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+_load_root_env()
+
 
 try:
     __version__ = version("ov-trader")

--- a/start.ps1
+++ b/start.ps1
@@ -1,0 +1,118 @@
+[CmdletBinding()]
+param(
+    [switch]$NoBackend,
+    [switch]$NoFrontend
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Set-ProcessEnvironmentFromFile {
+    param(
+        [string]$FilePath
+    )
+
+    if (-not (Test-Path -LiteralPath $FilePath)) {
+        Write-Verbose "No environment file found at $FilePath"
+        return
+    }
+
+    Write-Host "Loading environment variables from $FilePath" -ForegroundColor Cyan
+    foreach ($line in Get-Content -LiteralPath $FilePath) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed)) { continue }
+        if ($trimmed.StartsWith('#')) { continue }
+        $parts = $trimmed.Split('=', 2)
+        if ($parts.Length -ne 2) { continue }
+
+        $name = $parts[0].Trim()
+        $value = $parts[1].Trim().Trim('"').Trim("'")
+        if (-not $name) { continue }
+
+        if (-not $env:$name) {
+            Set-Item -Path "env:$name" -Value $value
+        }
+    }
+}
+
+function Assert-Command {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found on PATH."
+    }
+}
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $scriptRoot
+
+Set-ProcessEnvironmentFromFile -FilePath (Join-Path $scriptRoot '.env')
+
+if (-not $NoBackend) {
+    Assert-Command -Name 'python'
+}
+
+if (-not $NoFrontend) {
+    Assert-Command -Name 'npm'
+}
+
+$apiHost = if ($env:OV_TRADER_API_HOST) { $env:OV_TRADER_API_HOST } else { '127.0.0.1' }
+$apiPort = if ($env:OV_TRADER_API_PORT) { $env:OV_TRADER_API_PORT } else { '8000' }
+$webHost = if ($env:OV_TRADER_WEB_HOST) { $env:OV_TRADER_WEB_HOST } else { '127.0.0.1' }
+$webPort = if ($env:OV_TRADER_WEB_PORT) { $env:OV_TRADER_WEB_PORT } else { '3000' }
+
+if (-not $env:NEXT_PUBLIC_API_BASE_URL) {
+    $env:NEXT_PUBLIC_API_BASE_URL = "http://$apiHost`:$apiPort"
+}
+
+$processes = @()
+
+if (-not $NoBackend) {
+    Write-Host "Starting FastAPI backend on http://$apiHost`:$apiPort" -ForegroundColor Green
+    $backendArgs = @('-m', 'uvicorn', 'ov_trader.server.api:app', '--reload', '--host', $apiHost, '--port', $apiPort)
+    $backend = Start-Process -FilePath 'python' -ArgumentList $backendArgs -WorkingDirectory $scriptRoot -PassThru -NoNewWindow
+    $processes += $backend
+}
+
+if (-not $NoFrontend) {
+    Write-Host "Starting Next.js frontend on http://$webHost`:$webPort" -ForegroundColor Green
+    $webDirectory = Join-Path $scriptRoot 'web'
+    $frontendArgs = @('run', 'dev', '--', '--hostname', $webHost, '--port', $webPort)
+    $frontend = Start-Process -FilePath 'npm' -ArgumentList $frontendArgs -WorkingDirectory $webDirectory -PassThru -NoNewWindow
+    $processes += $frontend
+}
+
+if ($processes.Count -eq 0) {
+    Write-Warning 'No processes were started. Use the switches to enable the backend and/or frontend.'
+    exit 0
+}
+
+Write-Host 'Press Ctrl+C to stop both services.' -ForegroundColor Yellow
+
+try {
+    while ($true) {
+        Start-Sleep -Seconds 1
+        foreach ($proc in $processes) {
+            if ($proc.HasExited) {
+                throw "Process $($proc.ProcessName) (PID $($proc.Id)) exited with code $($proc.ExitCode)."
+            }
+        }
+    }
+}
+catch {
+    Write-Warning $_
+}
+finally {
+    foreach ($proc in $processes) {
+        if ($null -ne $proc -and -not $proc.HasExited) {
+            Write-Host "Stopping $($proc.ProcessName) (PID $($proc.Id))" -ForegroundColor DarkYellow
+            try {
+                $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+            }
+            catch {
+                Write-Verbose "Failed to stop process $($proc.ProcessName): $_"
+            }
+        }
+    }
+}

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,3 +1,25 @@
+import fs from "fs";
+import path from "path";
+
+const rootEnvPath = path.resolve(process.cwd(), "..", ".env");
+
+if (fs.existsSync(rootEnvPath)) {
+  const lines = fs.readFileSync(rootEnvPath, "utf-8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || !trimmed.includes("=")) {
+      continue;
+    }
+
+    const [name, ...rest] = trimmed.split("=");
+    const value = rest.join("=").trim().replace(/^['"]|['"]$/g, "");
+
+    if (name && !process.env[name]) {
+      process.env[name] = value;
+    }
+  }
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {


### PR DESCRIPTION
## Summary
- add a repository-level `.env` with shared settings and auto-load it inside the Python package
- teach the Next.js config to read the same `.env` file and provide a PowerShell launcher to start both services
- document the unified workflow and adjust ignored environment files

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68dbfc9032c0832b8b2fb8475f94be7f