### PR TITLE
Fix environment variable detection in PowerShell start script

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -28,7 +28,8 @@ function Set-ProcessEnvironmentFromFile {
         $value = $parts[1].Trim().Trim('"').Trim("'")
         if (-not $name) { continue }
 
-        if (-not $env:$name) {
+        $existingItem = Get-Item -Path "env:$name" -ErrorAction SilentlyContinue
+        if (-not $existingItem -or [string]::IsNullOrEmpty($existingItem.Value)) {
             Set-Item -Path "env:$name" -Value $value
         }
     }


### PR DESCRIPTION
## Summary
- avoid invalid dynamic environment-variable lookup syntax in `start.ps1`
- ensure existing environment variables are preserved when loading from `.env`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0592b92c832bb6b6a418d152eca6