### PR TITLE
Pin pandas/numpy versions to avoid binary mismatch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pandas>=2.0
-numpy>=1.24
+pandas==2.1.4
+numpy==1.26.4
 microsoft-qlib>=0.9.0
 pytrader @ git+https://github.com/jeanboydev/pytrader-api.git
 openai>=1.0


### PR DESCRIPTION
## Summary
- pin pandas 2.1.4 and numpy 1.26.4 in requirements to avoid binary incompatibility during backend startup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc097eee68832b9cdcb56dfaf9de71