### PR TITLE
Fix pandas import crash and clean Next.js config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pandas==2.1.4
-numpy==1.26.4
+pandas==2.2.2
+numpy==2.0.1
 microsoft-qlib>=0.9.0
 pytrader @ git+https://github.com/jeanboydev/pytrader-api.git
 openai>=1.0

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -21,10 +21,6 @@ if (fs.existsSync(rootEnvPath)) {
 }
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    serverActions: true,
-  },
-};
+const nextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- align the pinned numpy/pandas versions to the latest compatible releases to avoid binary import errors
- remove the deprecated experimental.serverActions flag from the Next.js configuration

## Testing
- pytest *(fails in the container because pandas is not installed in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0ba29eb4832bb92ec968feadc412