### PR TITLE
Document optional PyTrader dependency and clarify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ for LLM-powered research agents.
     portfolio instruction.
   - **PortfolioAgent** – converts alpha signals into target allocations with
     simple risk constraints.
-  - **ExecutionAgent** – bridges to brokers via [PyTrader](https://github.com/MetaQuotes/MetaTrader5-API).
+  - **ExecutionAgent** – bridges to brokers via the PyTrader API (optional manual install).
 - Configurable data ingestion via Qlib bundles for equities and crypto.
 - Backtesting harness using Qlib's `TopkDropoutStrategy`.
 - CLI entry point for running a full decision cycle.
@@ -41,8 +41,12 @@ for LLM-powered research agents.
    pip install -r requirements.txt
    ```
 
-   Required packages include `microsoft-qlib`, `pytrader`, `pandas`, `numpy`, and
-   an LLM client (e.g. `openai`).  Many of these libraries require Python 3.10+.
+   Required packages include `microsoft-qlib`, `pandas`, `numpy`, and an LLM
+   client (e.g. `openai`).  Many of these libraries require Python 3.10+.
+
+   The PyTrader bridge is not distributed via PyPI and must be installed
+   separately if you plan to connect to a MetaTrader brokerage.  See
+   [Optional: install PyTrader](#optional-install-pytrader) for guidance.
 
 2. Download the Qlib US data bundle:
 
@@ -150,6 +154,23 @@ From the UI you can:
 - Review per-agent transcripts alongside portfolio instructions.
 - Edit data, risk, execution, and LLM configuration values without touching
   configuration files.
+
+### Optional: install PyTrader
+
+The execution layer integrates with the proprietary
+[`pytrader_api`](https://github.com/jeanboydev/pytrader-api) client used to
+bridge into MetaTrader terminals.  That repository is private and not published
+on PyPI.  If you have access rights, install it manually after the base
+dependencies:
+
+```bash
+pip install git+https://github.com/jeanboydev/pytrader-api.git
+```
+
+If you do not install the client, the `ExecutionAgent` will remain inactive and
+raise a descriptive error when asked to submit live orders.  The rest of the
+research workflow—including data ingestion, forecasting, decisioning, and
+backtesting—continues to operate without it.
 
 ## Extending the system
 

--- a/ov_trader/agents/execution_agent.py
+++ b/ov_trader/agents/execution_agent.py
@@ -37,7 +37,10 @@ class ExecutionAgent(BaseAgent):
 
     def connect(self) -> None:
         if Pytrader_API is None:
-            raise RuntimeError("pytrader is not installed; execution agent cannot connect")
+            raise RuntimeError(
+                "PyTrader API is not installed. Install the private pytrader_api package "
+                "to enable live execution (see README section 'Optional: install PyTrader')."
+            )
         self.client = Pytrader_API()
         self.client.connect(
             self.config.server_host,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 pandas==2.2.2
 numpy==2.0.1
 microsoft-qlib>=0.9.0
-pytrader @ git+https://github.com/jeanboydev/pytrader-api.git
+# The PyTrader API is an optional dependency sourced from a private repository.
+# See README for manual installation steps if you have access to the provider's client.
 openai>=1.0
 requests>=2.31
 fastapi>=0.110


### PR DESCRIPTION
## Summary
- remove the private PyTrader repository from the default requirements list
- document that the PyTrader API must be installed manually and provide guidance in the README
- surface a clearer runtime error when execution is attempted without the PyTrader client

## Testing
- pytest *(fails: missing microsoft-qlib wheel for Python 3.12)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1e737bec832b8f6ab4123b5b1e1f