### PR TITLE
Pin numpy below 2.0 for pandas compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ for LLM-powered research agents.
    Required packages include `microsoft-qlib`, `pandas`, `numpy`, and an LLM
    client (e.g. `openai`).  Many of these libraries require Python 3.10+.
 
+   > **Note:** The project intentionally pins NumPy below 2.0 because the
+   > official pandas wheels for Windows are still built against the 1.26.x ABI.
+   > If you installed an earlier dependency set, reinstalling with the updated
+   > requirements file will resolve `ValueError: numpy.dtype size changed` errors
+   > when importing pandas.
+
    The PyTrader bridge is not distributed via PyPI and must be installed
    separately if you plan to connect to a MetaTrader brokerage.  See
    [Optional: install PyTrader](#optional-install-pytrader) for guidance.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
-pandas==2.2.2
-numpy==2.0.1
+pandas>=2.2.2,<2.3
+# Pin NumPy below 2.0 to avoid binary compatibility issues with the
+# prebuilt pandas wheels on Windows. NumPy 1.26.4 is the latest release
+# in the 1.x series and works with pandas 2.2.x while keeping qlib happy.
+numpy>=1.26.4,<2.0
 microsoft-qlib>=0.9.0
 # The PyTrader API is an optional dependency sourced from a private repository.
 # See README for manual installation steps if you have access to the provider's client.


### PR DESCRIPTION
## Summary
- pin NumPy to the 1.26.x series to avoid the Windows pandas binary incompatibility
- document the dependency pin and reinstall guidance in the quick start instructions

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68dc20b5cb7c832bbe473fe807c06776