### PR TITLE
Expose quickstart demo and wallet controls in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ From the UI you can:
 - Review per-agent transcripts alongside portfolio instructions.
 - Edit data, risk, execution, and LLM configuration values without touching
   configuration files.
+- Execute the synthetic quickstart demo, monitor the virtual wallet balance, and
+  review the resulting alpha/portfolio payloads without touching the CLI.
 
 ### Optional: install PyTrader
 

--- a/web/app/api/demo/route.ts
+++ b/web/app/api/demo/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+
+import { backendUnavailableResponse, proxyFetch } from "@/lib/server-proxy";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const response = await proxyFetch("/demo", {
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      return NextResponse.json({ error: text || response.statusText }, { status: response.status });
+    }
+    const data = text ? JSON.parse(text) : {};
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    return backendUnavailableResponse("Unable to retrieve demo history");
+  }
+}
+
+export async function POST(request: Request) {
+  const body = await request.text();
+  try {
+    const response = await proxyFetch("/demo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body,
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      return NextResponse.json({ error: text || response.statusText }, { status: response.status });
+    }
+    const data = text ? JSON.parse(text) : {};
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    return backendUnavailableResponse("Unable to run the sample demo");
+  }
+}

--- a/web/components/SampleDemoPanel.tsx
+++ b/web/components/SampleDemoPanel.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState } from "react";
+
+import { DemoRunRecord } from "@/lib/types";
+
+interface SampleDemoPanelProps {
+  busy: boolean;
+  latestDemo: DemoRunRecord | null;
+  demos: DemoRunRecord[];
+  onRunDemo: (options?: { initialBalance?: number; notes?: string }) => void;
+}
+
+export default function SampleDemoPanel({
+  busy,
+  latestDemo,
+  demos,
+  onRunDemo,
+}: SampleDemoPanelProps) {
+  const [initialBalance, setInitialBalance] = useState<number>(100);
+  const [notes, setNotes] = useState<string>("");
+
+  const historyRows = useMemo(() => {
+    if (!latestDemo?.wallet?.history) return [];
+    return latestDemo.wallet.history;
+  }, [latestDemo?.wallet?.history]);
+
+  return (
+    <section className="card space-y-4">
+      <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Sample Demo (Synthetic Market)</h2>
+          <p className="muted text-sm">
+            Runs the CLI quickstart scenario directly from the dashboard. Synthetic price data is
+            piped through the alpha model and tracked in a virtual wallet.
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+          <label className="flex flex-col text-sm font-medium">
+            Initial balance
+            <input
+              className="input"
+              type="number"
+              min={1}
+              step={1}
+              value={initialBalance}
+              onChange={(event) => setInitialBalance(Number(event.target.value))}
+              disabled={busy}
+            />
+          </label>
+          <label className="flex flex-col text-sm font-medium">
+            Notes (optional)
+            <input
+              className="input"
+              type="text"
+              placeholder="Why run this demo?"
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              disabled={busy}
+            />
+          </label>
+          <button
+            type="button"
+            className="btn btn-primary self-start sm:self-auto"
+            onClick={() => onRunDemo({
+              initialBalance: Number.isFinite(initialBalance) ? initialBalance : undefined,
+              notes: notes.trim() || undefined,
+            })}
+            disabled={busy}
+          >
+            {busy ? "Running..." : "Run sample demo"}
+          </button>
+        </div>
+      </header>
+
+      {latestDemo ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <h3 className="font-semibold">Virtual wallet</h3>
+            <div className="rounded border border-slate-700 bg-slate-900/50 p-3 text-sm">
+              <p className="font-medium">{latestDemo.wallet.summary}</p>
+              <p className="text-xs text-slate-400">
+                Started with {latestDemo.wallet.starting_balance.toFixed(2)} {latestDemo.wallet.label}
+                . Final balance {latestDemo.wallet.balance.toFixed(2)} {latestDemo.wallet.label}.
+              </p>
+            </div>
+            <div>
+              <h4 className="text-sm font-semibold text-slate-300">Balance history</h4>
+              <ul className="mt-2 space-y-1 text-sm">
+                {historyRows.map((row) => (
+                  <li key={`${row.label}-${row.balance}`} className="flex justify-between">
+                    <span className="text-slate-400">{row.label}</span>
+                    <span className="font-mono">{row.balance.toFixed(2)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+          <div className="space-y-3">
+            <h3 className="font-semibold">Analytics snapshots</h3>
+            <div className="text-sm text-slate-300">
+              <p>
+                <span className="font-medium">Alpha signals:</span> {formatDataSize(latestDemo.alpha)}
+              </p>
+              <p>
+                <span className="font-medium">Target weights:</span> {formatDataSize(latestDemo.weights)}
+              </p>
+              <p>
+                <span className="font-medium">Portfolio returns:</span> {formatDataSize(latestDemo.portfolio_returns)}
+              </p>
+              <p className="text-xs text-slate-500">
+                View detailed payloads in the API response or data explorer of your choice.
+              </p>
+            </div>
+            <div>
+              <h4 className="text-sm font-semibold text-slate-300">Recent demo runs</h4>
+              <ul className="mt-2 space-y-1 text-sm">
+                {demos.map((demo) => (
+                  <li key={demo.id} className="flex justify-between">
+                    <span className="text-slate-400">
+                      {new Date(demo.timestamp).toLocaleString()}
+                    </span>
+                    <span className="font-mono">
+                      {demo.wallet.balance.toFixed(2)} {demo.wallet.label}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-slate-400">
+          No demo has been executed yet. Configure an initial balance and run the scenario to see the
+          wallet evolve over the synthetic market sample.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function formatDataSize(payload: Record<string, unknown> | undefined): string {
+  if (!payload) return "n/a";
+  const keys = Object.keys(payload);
+  if (keys.length === 0) return "empty";
+  return `${keys.length} keys`;
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,7 +1,60 @@
-import { DashboardData, RunRecord, BacktestRecord, TraderConfig } from "./types";
+import {
+  DashboardData,
+  RunRecord,
+  BacktestRecord,
+  TraderConfig,
+  DemoRunRecord,
+} from "./types";
 import { createEmptyDashboard } from "./fallback";
 
-const API_BASE = (process.env.NEXT_PUBLIC_API_BASE_URL ?? "/api").replace(/\/$/, "");
+function normaliseBase(base: string): string {
+  return base.replace(/\/$/, "");
+}
+
+function getApiBases(): string[] {
+  const isServer = typeof window === "undefined";
+  const candidates = isServer
+    ? [
+        process.env.API_BASE_URL,
+        process.env.NEXT_PUBLIC_API_BASE_URL,
+        "http://127.0.0.1:8000",
+        "http://localhost:8000",
+      ]
+    : [process.env.NEXT_PUBLIC_API_BASE_URL, "/api"];
+
+  const bases: string[] = [];
+  for (const value of candidates) {
+    if (!value) continue;
+    const normalised = normaliseBase(value);
+    if (!bases.includes(normalised)) {
+      bases.push(normalised);
+    }
+  }
+
+  if (bases.length === 0) {
+    bases.push(isServer ? "http://127.0.0.1:8000" : "/api");
+  }
+
+  return bases;
+}
+
+async function fetchFromApi(path: string, init?: RequestInit): Promise<Response> {
+  const bases = getApiBases();
+  let lastError: unknown = null;
+
+  for (const base of bases) {
+    try {
+      const url = base.startsWith("http") ? `${base}${path}` : `${base}${path}`;
+      return await fetch(url, init);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Unable to reach OV Trader API");
+}
 
 async function parseResponse<T>(response: Response): Promise<T> {
   const text = await response.text();
@@ -25,7 +78,7 @@ async function parseResponse<T>(response: Response): Promise<T> {
 
 export async function fetchDashboard(): Promise<DashboardData> {
   try {
-    const response = await fetch(`${API_BASE}/dashboard`, {
+    const response = await fetchFromApi("/dashboard", {
       cache: "no-store",
       headers: { Accept: "application/json" },
     });
@@ -43,7 +96,7 @@ export async function runTradingCycle(body?: {
   notes?: string;
   overrideConfig?: Partial<TraderConfig>;
 }): Promise<RunRecord> {
-  const response = await fetch(`${API_BASE}/runs`, {
+  const response = await fetchFromApi("/runs", {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
     body: JSON.stringify(body ?? {}),
@@ -56,7 +109,7 @@ export async function startBacktest(body?: {
   notes?: string;
   overrideConfig?: Partial<TraderConfig>;
 }): Promise<BacktestRecord> {
-  const response = await fetch(`${API_BASE}/backtests`, {
+  const response = await fetchFromApi("/backtests", {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
     body: JSON.stringify(body ?? {}),
@@ -66,7 +119,7 @@ export async function startBacktest(body?: {
 }
 
 export async function saveConfig(config: TraderConfig): Promise<DashboardData["config"]> {
-  const response = await fetch(`${API_BASE}/config`, {
+  const response = await fetchFromApi("/config", {
     method: "PUT",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
     body: JSON.stringify(config),
@@ -77,4 +130,20 @@ export async function saveConfig(config: TraderConfig): Promise<DashboardData["c
 
 export async function refreshDashboard(): Promise<DashboardData> {
   return fetchDashboard();
+}
+
+export async function runSampleDemo(body?: {
+  initialBalance?: number;
+  notes?: string;
+}): Promise<DemoRunRecord> {
+  const response = await fetchFromApi("/demo", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({
+      initialBalance: body?.initialBalance,
+      notes: body?.notes,
+    }),
+  });
+  const data = await parseResponse<{ demo: DemoRunRecord }>(response);
+  return data.demo;
 }

--- a/web/lib/fallback.ts
+++ b/web/lib/fallback.ts
@@ -50,7 +50,9 @@ export function createEmptyDashboard(error?: string): DashboardData {
     latest_run: null,
     runs: [],
     backtests: [],
-    metrics: { total_runs: 0, total_backtests: 0 },
+    latest_demo: null,
+    demos: [],
+    metrics: { total_runs: 0, total_backtests: 0, total_demos: 0 },
     error,
   };
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -105,6 +105,27 @@ export interface BacktestRecord {
 export interface DashboardMetrics {
   total_runs: number;
   total_backtests: number;
+  total_demos?: number;
+}
+
+export interface WalletSnapshot {
+  label: string;
+  starting_balance: number;
+  balance: number;
+  summary: string;
+  history: { label: string; balance: number }[];
+}
+
+export interface DemoRunRecord {
+  id: string;
+  timestamp: string;
+  duration?: number;
+  initial_balance: number;
+  wallet: WalletSnapshot;
+  alpha?: Record<string, unknown>;
+  weights?: Record<string, unknown>;
+  portfolio_returns?: Record<string, unknown>;
+  notes?: string;
 }
 
 export interface DashboardData {
@@ -112,6 +133,8 @@ export interface DashboardData {
   latest_run: RunRecord | null;
   runs: RunRecord[];
   backtests: BacktestRecord[];
+  latest_demo: DemoRunRecord | null;
+  demos: DemoRunRecord[];
   metrics: DashboardMetrics;
   error?: string;
 }


### PR DESCRIPTION
## Summary
- add FastAPI endpoints to run and list the synthetic quickstart demo alongside existing trading/backtest operations
- extend the trading service and dashboard payloads to surface virtual wallet analytics and demo history
- enhance the Next.js client with a sample demo panel and resilient API fetching that falls back to the direct backend URL

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68dc22e907d0832ba98b4b6f7d6307d4